### PR TITLE
Baseline navigation

### DIFF
--- a/app/baseline/controller/baseline.js
+++ b/app/baseline/controller/baseline.js
@@ -82,6 +82,9 @@ function BaselineController($rootScope,
     };
 
 
+    vm.residencyStartType = "CEN"
+
+
     vm.saveLocationHierarchy = function() {
         var parentIndex = vm.selectedHierarchy.length - 2;
         var lastIndex = vm.selectedHierarchy.length - 1;

--- a/app/baseline/view/baseline.html
+++ b/app/baseline/view/baseline.html
@@ -9,8 +9,7 @@
       <ng-include src="'core/partials/navigationTabs.html'"></ng-include>
       <hr>
 
-      <!-- For debugging. TODO: Remove when unneeded -->
-      <ng-include src="'core/partials/entityStatusBaseline.html'"></ng-include>
+      
 
     </div>
 

--- a/app/baseline/view/baseline.html
+++ b/app/baseline/view/baseline.html
@@ -9,7 +9,7 @@
       <ng-include src="'core/partials/navigationTabs.html'"></ng-include>
       <hr>
 
-      
+
 
     </div>
 

--- a/app/baseline/view/baselineInit.html
+++ b/app/baseline/view/baselineInit.html
@@ -19,13 +19,15 @@
 
         <button id="next"
                 class="btn btn-primary pull-right"
-                onClick="$('#locationTab').tab('show')">
+                onClick="$('#locationTab').tab('show')"
+                ng-disabled="model.collectionDateTime == null;model.currentFieldWorker == null;model.currentHierarchy == null">
             Location
             <span class="glyphicon glyphicon-arrow-right"></span>
         </button>
 
     </fieldset>
 </div>
+
 
 
 <ng-include src="'domain/fieldworker/partials/fieldWorkerSelectModal.html'"></ng-include>

--- a/app/baseline/view/baselineTabBarPartial.html
+++ b/app/baseline/view/baselineTabBarPartial.html
@@ -5,22 +5,26 @@
       Baseline
     </a>
   </li>
-  <li role="presentation">
+  <li role="presentation"
+      ng-hide="model.collectionDateTime == null;model.currentFieldWorker == null;model.currentHierarchy == null">
     <a role="tab" id="locationTab" data-toggle="tab" data-target="#location">
       Location
     </a>
   </li>
-  <li role="presentation">
+  <li role="presentation"
+      ng-hide="model.selectedLocation == null">
     <a role="tab" id="groupTab" data-toggle="tab" data-target="#group">
       Group
     </a>
   </li>
-  <li role="presentation">
+  <li role="presentation"
+      ng-hide="model.selectedSocialGroups.length < 1">
     <a role="tab" id="individualsTab" data-toggle="tab" data-target="#individuals">
       Individuals
     </a>
   </li>
-  <li role="presentation">
+  <li role="presentation"
+      ng-hide="model.selectedIndividuals.length < 1">
     <a role="tab" id="relationshipsTab" data-toggle="tab" data-target="#relationships">
       Relationships
     </a>

--- a/app/baseline/view/individualBaseline.html
+++ b/app/baseline/view/individualBaseline.html
@@ -75,7 +75,8 @@
 
 <button id="startRelationships"
         class="btn btn-primary pull-right"
-        onClick="$('#relationshipsTab').tab('show')">
+        onClick="$('#relationshipsTab').tab('show')"
+        ng-disabled="model.selectedIndividuals.length < 1">
     Relationships
     <span class="glyphicon glyphicon-arrow-right"></span>
 </button>

--- a/app/baseline/view/individualBaseline.html
+++ b/app/baseline/view/individualBaseline.html
@@ -39,7 +39,7 @@
         <td>{{row.extId}}</td>
         <td>{{row.gender}}</td>
         <td>
-            <button type="button" ng-click="model.removeSelectedEntity('selectedIndividual',row)" class="btn btn-sm btn-danger">
+            <button type="button" ng-click="model.removeSelectedEntity('selectedIndividuals',row)" class="btn btn-sm btn-danger">
                 <i class="glyphicon glyphicon-remove-circle">
                 </i>
             </button>

--- a/app/baseline/view/locationBaseline.html
+++ b/app/baseline/view/locationBaseline.html
@@ -41,7 +41,10 @@
 
 <hr>
 
-<button id="startSocialGroups" class="btn btn-primary pull-right" onClick="$('#groupTab').tab('show')">
+<button id="startSocialGroups"
+        class="btn btn-primary pull-right"
+        onClick="$('#groupTab').tab('show')"
+        ng-disabled="model.selectedLocation == null">
     Social Groups
     <span class="glyphicon glyphicon-arrow-right"></span>
 </button>

--- a/app/baseline/view/relationshipBaseline.html
+++ b/app/baseline/view/relationshipBaseline.html
@@ -39,7 +39,15 @@
 </table>
 <hr>
 
-<button class="btn btn-primary pull-right" data-toggle="tab" data-target="#relationships">
+<button class="btn btn-primary pull-right"
+        data-toggle="tab"
+        data-target="#baseline"
+        ng-click="model.selectedLocation = null;
+                  model.selectedSocialGroups = [];
+                  model.selectedIndividuals=[];
+                  model.currentIndividual=null;
+                  model.submittedMemberships = [];
+                  model.submittedRelationships = []">
     Complete Baseline
     <span class="glyphicon glyphicon-arrow-right"></span>
 </button>

--- a/app/baseline/view/socialGroupBaseline.html
+++ b/app/baseline/view/socialGroupBaseline.html
@@ -43,7 +43,8 @@
 <hr>
 <button id="startIndividuals"
         class="btn btn-primary pull-right"
-        onClick="$('#individualsTab').tab('show')">
+        onClick="$('#individualsTab').tab('show')"
+        ng-disabled="model.selectedSocialGroups.length < 1">
     Individuals
     <span class="glyphicon glyphicon-arrow-right"></span>
 </button>

--- a/app/domain/individual/partials/individualCreateModal.html
+++ b/app/domain/individual/partials/individualCreateModal.html
@@ -34,14 +34,7 @@
                              ng-model="model.individual.dateOfBirth"></datebox>
                     <br /><br />
 
-                    <selectbox ng-model="model.residencyStartType"
-                               id="residencyStartType" label="Residency Start Type">
-                        <option ng-if="code.codeGroup === 'membershipType'"
-                                ng-repeat="code in model.codes"
-                                value="{{code.codeValue}}">{{code.codeName}}
-                        </option>
-                    </selectbox>
-                    <br /><br />
+
                     <datebox label="Residency Start Date" id="residencyStartDate"
                              ng-model="model.residencyStartDate"></datebox>
                     <br /><br />


### PR DESCRIPTION
Does the following: 
- Remove View Current Entities
- Complete Baseline should clear entities
- Complete Baseline should go back to baseline tab 
- Disable buttons until required variables for that stage are selected (ng-disable)
- Hide tabs as we go along, same logic as button disables (ng-hide)
- Fixes remove individual from selected list button
- Residency start type for baseline preset to 'CEN'. User option removed. 
